### PR TITLE
Update dark mode toggle and styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -38,6 +38,15 @@
   --gradient-start-color: rgba(0, 0, 0, 0.3); /* Darker gradient for showcase */
   --gradient-end-color: rgba(50, 50, 50, 0.5); /* Darker gradient for showcase */
   --box-shadow-color: rgba(255, 255, 255, 0.05); /* Lighter shadow for dark mode */
+
+  /* Specific adjustments for dark mode */
+  .showcase-container p {
+    color: #fff; /* Ensure showcase paragraph text is white in dark mode */
+  }
+
+  .img-container::after {
+    background: rgba(0, 0, 0, 0.871); /* Keep original overlay color in dark mode */
+  }
 }
 
 * {
@@ -181,6 +190,15 @@ body {
   /* Sets font size for the logo */
   /* Adds bottom margin to the logo */
   /* margin-bottom: 0.5rem;  */
+}
+
+#darkModeIcon {
+  color: var(--text-color);
+  font-size: 1.6rem; /* Adjust as needed, similar to menu items or slightly larger */
+  margin-left: 1.5rem; /* Spacing from menu items or logo */
+  cursor: pointer;
+  order: 3; /* To place it after menu items */
+  align-self: center; /* Explicitly align if needed */
 }
 
 
@@ -673,7 +691,13 @@ body {
   } */
 
   .menu-items {
-    display: none;
+    display: none; /* Menu items are hidden, icon should still be visible */
+  }
+
+  /* Ensure icon is visible and correctly ordered when menu items are hidden */
+  #darkModeIcon {
+    order: 2; /* After logo (order 1) when menu-items (order 2 originally) are hidden */
+    /* margin-left can remain, or adjust if it looks off without menu items */
   }
 
   .food-menu-container img {

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         <li><a href="#testimonials">Testimonial</a></li> <!-- Link to the testimonials section -->
         <li><a href="#contact">Contact</a></li> <!-- Link to the contact section -->
       </ul>
-      <button id="darkModeToggle" style="padding: 5px 10px; margin-left: 15px;">Toggle Dark Mode</button> <!-- Dark Mode Toggle Button -->
+      <i class="fas fa-moon" id="darkModeIcon"></i> <!-- Dark Mode Toggle Icon -->
       <div class="bar-icon">
         <i class="fa-solid fa-bars"></i>
       </div>
@@ -274,19 +274,23 @@
   </footer>
 
   <script>
-    const darkModeToggle = document.getElementById('darkModeToggle');
+    const darkModeIcon = document.getElementById('darkModeIcon');
     const body = document.body;
     const DARK_MODE_KEY = 'darkMode';
 
     // Function to apply dark mode
     const enableDarkMode = () => {
       body.classList.add('dark-mode');
+      darkModeIcon.classList.remove('fa-moon');
+      darkModeIcon.classList.add('fa-sun');
       localStorage.setItem(DARK_MODE_KEY, 'enabled');
     }
 
     // Function to disable dark mode
     const disableDarkMode = () => {
       body.classList.remove('dark-mode');
+      darkModeIcon.classList.remove('fa-sun');
+      darkModeIcon.classList.add('fa-moon');
       localStorage.setItem(DARK_MODE_KEY, 'disabled');
     }
 
@@ -294,12 +298,12 @@
     if (localStorage.getItem(DARK_MODE_KEY) === 'enabled') {
       enableDarkMode();
     } else {
-      // Optional: default to light mode if no preference or it's 'disabled'
+      // Default to light mode if no preference or it's 'disabled'
       disableDarkMode();
     }
 
-    // Toggle dark mode on button click
-    darkModeToggle.addEventListener('click', () => {
+    // Toggle dark mode on icon click
+    darkModeIcon.addEventListener('click', () => {
       if (body.classList.contains('dark-mode')) {
         disableDarkMode();
       } else {


### PR DESCRIPTION
This commit implements your feedback on the dark mode feature:

- Replaced the dark mode toggle button with a moon/sun icon.
- Positioned the icon to the right of the navbar and ensured responsive behavior.
- Updated JavaScript to manage the icon state (moon/sun) based on the selected theme.
- Adjusted dark mode styles:
    - Set the text color of "Eat Healthy, it is good for our health." in the showcase area to white.
    - Ensured the background of the slide animation for images in the "Types of food" section remains unchanged (dark overlay) in dark mode.

All changes have been tested for functionality and visual correctness.